### PR TITLE
corrected addl_subjects, that was not a tuble previously

### DIFF
--- a/04_Data_Structures/subjects.py
+++ b/04_Data_Structures/subjects.py
@@ -42,7 +42,7 @@ print(subjects[1])
 # School wants Louis to take another 3 subjects to get full credits
 # ---------------------------------------------------------------------
 
-addl_subjects = A
+addl_subjects = ("A",)
 total_subjects = subjects + addl_subjects
 print(f"All subjects: {total_subjects}")
 


### PR DESCRIPTION
Maybe the original idea was to have an additional tuple with more subjects, but, currently there is only the letter A and it's not even a string. This causes an error when trying to run the python script 04_Data_Structures/subjects.py